### PR TITLE
Remove warning when network is correct

### DIFF
--- a/components/metaMask/SwitchNetworkAlert.tsx
+++ b/components/metaMask/SwitchNetworkAlert.tsx
@@ -15,7 +15,7 @@ export const SwitchNetworkAlert: React.FC = () => {
   const { activeChain, switchNetwork } = useNetwork()
   const [isDesktopOrTablet] = useMediaQuery('(min-width:600px)')
 
-  if (activeChain == chain.polygon) {
+  if (activeChain?.id == chain.polygon.id) {
     return <></>
   }
 
@@ -26,7 +26,9 @@ export const SwitchNetworkAlert: React.FC = () => {
     >
       <AlertIcon />
       <AlertDescription>
-      {t('SWITCH_NETWORK_MSG_1')}{activeChain?.name}{t('SWITCH_NETWORK_MSG_2')}
+        {t('SWITCH_NETWORK_MSG_1')}
+        {activeChain?.name}
+        {t('SWITCH_NETWORK_MSG_2')}
       </AlertDescription>
 
       <Button

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -47,7 +47,7 @@
   "QUESTS_SUBMIT_BUTTON": "Submit Keyword",
 
   "SWITCH_NETWORK_MSG_1": "You are using ",
-  "SWITCH_NETWORK_MSG_2": ". To use this app, switch to Polygon mainnet.",
+  "SWITCH_NETWORK_MSG_2": ". To use this app, switch to Polygon Mainnet.",
   "SWITCH_NETWORK_BUTTON": "Switch to Polygon",
 
   "LAYOUT_HEADING": "Omise – HENKAKU",

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -47,7 +47,7 @@
   "QUESTS_SUBMIT_BUTTON": "キーワードを送信",
 
   "SWITCH_NETWORK_MSG_1": "あなたは今",
-  "SWITCH_NETWORK_MSG_2": "を使っています。このウェブアプリを使うには、Polygon mainnetに切り替えてください。",
+  "SWITCH_NETWORK_MSG_2": "を使っています。このウェブアプリを使うには、Polygon Mainnetに切り替えてください。",
   "SWITCH_NETWORK_BUTTON": "Polygonに切り替える",
 
   "LAYOUT_HEADING": "Omise – HENKAKU",


### PR DESCRIPTION
It is better to display warnings only when necessary so that warnings are not ignored


before
<img width="1569" alt="スクリーンショット 2022-05-21 13 51 22" src="https://user-images.githubusercontent.com/701242/169635940-daa5eacd-81b6-4d7a-a18a-c096b2bcd4d3.png">

<img width="1586" alt="スクリーンショット 2022-05-21 13 53 18" src="https://user-images.githubusercontent.com/701242/169635991-85e0b1e6-23fe-4b2d-a853-5eb4b5d03f3c.png">


after
<img width="1562" alt="スクリーンショット 2022-05-21 13 51 43" src="https://user-images.githubusercontent.com/701242/169635951-8f269736-f38d-42e3-b519-661074cf5c11.png">

<img width="1569" alt="スクリーンショット 2022-05-21 13 52 49" src="https://user-images.githubusercontent.com/701242/169635981-32ab1017-9f31-4871-986d-543336d43cab.png">

