### PR TITLE
Fix Node version for CI

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,13 +9,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       # unable to use yarn in actions/setup-node@v3 https://github.com/actions/setup-node/issues/182#issuecomment-966885975
       - name: Install Yarn
         run: npm install -g yarn
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: yarn
       - name: Install packages
         run: yarn


### PR DESCRIPTION
## Summary
- use Node 18 in PR workflow to match repository requirements

## Testing
- `yarn lint`
- `yarn jest`


------
https://chatgpt.com/codex/tasks/task_e_6841a566be9883298d10f477e488a74b